### PR TITLE
enable pip install from git repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,28 @@ from setuptools import setup
 from subprocess import check_call
 from distutils.command.build import build
 from distutils.dir_util import copy_tree, remove_tree
+from setuptools.command.develop import develop
+
+def get_submodules_and_fix_paths():
+    if path.exists('.git'):
+        check_call(['git', 'submodule', 'init'])
+        check_call(['git', 'submodule', 'update'])
+        # Move contents of pagedown and remove .git
+        dst = "pagedown/static/pagedown/"
+        src = "pagedown/static/pagedown/pagedown/"
+        copy_tree(src, dst)
+        remove_tree(src)
 
 class build_with_submodules(build):
     def run(self):
-        if path.exists('.git'):
-            check_call(['git', 'submodule', 'init'])
-            check_call(['git', 'submodule', 'update'])
-            # Move contents of pagedown and remove .git
-            dst = "pagedown/static/pagedown/"
-            src = "pagedown/static/pagedown/pagedown/"
-            copy_tree(src, dst)
-            remove_tree(src)
+        get_submodules_and_fix_paths()
         build.run(self)
+
+class develop_with_submodules(develop):
+    def run(self):
+        get_submodules_and_fix_paths()
+        develop.run(self)
+
 
 setup(
   name = "django-pagedown",
@@ -31,5 +41,5 @@ setup(
     "Django >= 1.3",
   ],
   license='LICENSE.txt',
-  cmdclass={"build": build_with_submodules},
+  cmdclass={"build": build_with_submodules, "develop": develop_with_submodules},
 )


### PR DESCRIPTION
hey there,

this patch makes pip initialize the submodules when installing the package using

 git -e git+[repopath]

as it calls setup.py develop in these cases.
