### PR TITLE
fix pip install --upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools.command.develop import develop
 
 def get_submodules_and_fix_paths():
     if path.exists('.git'):
+        check_call(['rm', '-rf', 'pagedown/static/pagedown'])
         check_call(['git', 'reset', '--hard'])
         check_call(['git', 'submodule', 'init'])
         check_call(['git', 'submodule', 'update'])


### PR DESCRIPTION
hey there,

```
pip install --upgrade
```

failed with the previous setup.py, since the whole moving files around business triggered an error message when trying it again.

this seems to work better. tested uninstall, reinstall and upgrade.
