### PR TITLE
Example in README wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Alternatively, to only use it on particular fields, first create a form (in `for
 and in your `admin.py`:
 
 	from forms import FooModelForm
-    class FooModelAdmin(models.ModelAdmin):
+    class FooModelAdmin(admin.ModelAdmin):
     	form = FooModelForm   
  
  


### PR DESCRIPTION
Should be `admin` and not `model` in:

```
from forms import WidgetModelForm
class WidgetAdmin(model.ModelAdmin):
    form = WidgetModelForm  
```
