### PR TITLE
Remove double slash in form media

### DIFF
--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -12,9 +12,9 @@ class PagedownWidget(forms.Textarea):
         css = {
             'all': ('pagedown/demo/browser/demo.css',)
         }
-        js = ('%s/pagedown/Markdown.Converter.js' % settings.STATIC_URL,
-              '%s/pagedown/Markdown.Sanitizer.js' % settings.STATIC_URL,
-              '%s/pagedown/Markdown.Editor.js' % settings.STATIC_URL,)
+        js = ('%s/pagedown/Markdown.Converter.js' % settings.STATIC_URL.rstrip('/'),
+              '%s/pagedown/Markdown.Sanitizer.js' % settings.STATIC_URL.rstrip('/'),
+              '%s/pagedown/Markdown.Editor.js' % settings.STATIC_URL.rstrip('/'),)
 
     def render(self, name, value, attrs=None):
         if value is None:


### PR DESCRIPTION
If `settings.STATIC_URL` ends in a slash, it may raise a `SuspiciousOperation` error when run through tools like django-compressor. Removing trailing slashes from STATIC_URL fixes this.
