### PR TITLE
Remove the Javascript code from widgets.py

### DIFF
--- a/pagedown/static/pagedown_widget.js
+++ b/pagedown/static/pagedown_widget.js
@@ -1,0 +1,17 @@
+(function () {
+    var converter = Markdown.getSanitizingConverter(),
+        elements = document.querySelectorAll('[data-widget="PagedownWidget"]');
+
+    for (var i = 0; i < elements.length, el = elements[i]; ++i)
+    {
+        selectors = {
+            input : el.id,
+            button : el.id + "_wmd_button_bar",
+            preview : el.id + "_wmd_preview",
+        }
+
+        var editor = new Markdown.Editor(converter, "", selectors);
+
+        editor.run();
+    }
+})();

--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -12,9 +12,10 @@ class PagedownWidget(forms.Textarea):
         css = {
             'all': ('pagedown/demo/browser/demo.css',)
         }
-        js = ('%s/pagedown/Markdown.Converter.js' % settings.STATIC_URL.rstrip('/'),
-              '%s/pagedown/Markdown.Sanitizer.js' % settings.STATIC_URL.rstrip('/'),
-              '%s/pagedown/Markdown.Editor.js' % settings.STATIC_URL.rstrip('/'),)
+        js = ('%spagedown/Markdown.Converter.js' % settings.STATIC_URL,
+              '%spagedown/Markdown.Sanitizer.js' % settings.STATIC_URL,
+              '%spagedown/Markdown.Editor.js' % settings.STATIC_URL,
+              '%spagedown_widget.js' % settings.STATIC_URL)
 
     def render(self, name, value, attrs=None):
         if value is None:
@@ -22,6 +23,7 @@ class PagedownWidget(forms.Textarea):
         if 'class' not in attrs:
             attrs['class'] = ""
         attrs['class'] += " wmd-input"
+        attrs['data-widget'] = 'PagedownWidget'
         final_attrs = self.build_attrs(attrs, name=name)
         html = """
             <div class="wmd-wrapper">
@@ -31,18 +33,6 @@ class PagedownWidget(forms.Textarea):
                 </div>
                 <div id="%(id)s_wmd_preview" class="wmd-panel wmd-preview"></div>
             </div>
-            <script type="text/javascript">
-                (function () {
-                    var converter = Markdown.getSanitizingConverter();
-                    selectors = {
-                        input : "%(id)s",
-                        button : "%(id)s_wmd_button_bar",
-                        preview : "%(id)s_wmd_preview",
-                    }
-                    var editor = new Markdown.Editor(converter, "", selectors);
-                    editor.run();
-                })();
-            </script>
             """ % {
                 'attrs': flatatt(final_attrs),
                 'body': conditional_escape(force_unicode(value)),


### PR DESCRIPTION
The Javascript code embedded in the widgets.py file can cause some troubles regarding the order that scripts are being loaded.
