### PR TITLE
Declare egg to not be zip-safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,5 @@ setup(
   ],
   license='LICENSE.txt',
   cmdclass={"build": build_with_submodules, "develop": develop_with_submodules},
+  zip_safe=False,
 )


### PR DESCRIPTION
If the egg is installed zipped, `python manage.py collectstatic` will fail to find the resources under `static`.
