### PR TITLE
Use `django.templatetags.static`to load the file

### DIFF
--- a/pagedown/utils.py
+++ b/pagedown/utils.py
@@ -8,8 +8,8 @@ def compatible_staticpath(path):
     '''
     try:
         # >= 1.4
-        from django.contrib.staticfiles.storage import staticfiles_storage
-        return staticfiles_storage.url(path)
+        from django.templatetags.static import static
+        return static(path)
     except ImportError:
         pass
     try:


### PR DESCRIPTION
Allows the use of `CachedStaticFilesStorage` without getting `ValueError: The file 'admin/css/pagedown.css' could not be found` errors. Solves issue #25 .