### PR TITLE
Make media on AdminPagedownWidget lazy

### DIFF
--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -68,7 +68,7 @@ class PagedownWidget(forms.Textarea):
 
 class AdminPagedownWidget(PagedownWidget, admin_widgets.AdminTextareaWidget):
     def _media(self):
-        return forms.Media(
+        return super(AdminPagedownWidget, self).media + forms.Media(
             css={
                 "all": (compatible_staticpath("admin/css/pagedown.css"),)
             },

--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -67,10 +67,12 @@ class PagedownWidget(forms.Textarea):
 
 
 class AdminPagedownWidget(PagedownWidget, admin_widgets.AdminTextareaWidget):
-    class Media:
-        css = {
-            "all": (compatible_staticpath("admin/css/pagedown.css"),)
-        }
-        js = (
-            compatible_staticpath("admin/js/pagedown.js"),
-        )
+    def _media(self):
+        return forms.Media(
+            css={
+                "all": (compatible_staticpath("admin/css/pagedown.css"),)
+            },
+            js=(
+                compatible_staticpath("admin/js/pagedown.js"),
+            ))
+    media = property(_media)


### PR DESCRIPTION
This avoids resolving static files on import which may fail if static files are not in manifest when using ManifestStaticFilesStorage.

I had this problem when running `collectstatic` to build a manifest file. Before the management command could do its thing and create the manifest the import machinery imported `pagedown` and tried to resolve the static file via manifest which then failed. The lazy loading avoids this.