### PR TITLE
Lazily handle media for Django 1.10+

### DIFF
--- a/pagedown/utils.py
+++ b/pagedown/utils.py
@@ -1,12 +1,17 @@
+from django import VERSION
 from django.conf import settings
 
 
 def compatible_staticpath(path):
     '''
     Try to return a path to static the static files compatible all
-    the way back to Django 1.2. If anyone has a cleaner or better 
+    the way back to Django 1.2. If anyone has a cleaner or better
     way to do this let me know!
     '''
+    if VERSION >= (1, 10):
+        # Since Django 1.10, forms.Media automatically invoke static
+        # lazily on the path if it is relative.
+        return path
     try:
         # >= 1.4
         from django.templatetags.static import static


### PR DESCRIPTION
Since Django 1.10, `forms.Media` correctly invokes `static` on any media declared with a relative path, unlike previous versions, which did a simple `urljoin` of `STATIC_URL` and the relative path. Using relative paths directly solves an issue that leads to a crash on startup on Django 1.11, for which #52 is a quick fix. This pull request aims to solve the root of the problem.