### PR TITLE
custom attrs for widget

### DIFF
--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -48,6 +48,7 @@ class PagedownWidget(forms.Textarea):
             final_attrs = self.build_attrs(attrs, name=name)
         else:
             final_attrs = self.build_attrs(attrs, {'name': name})
+        final_attrs = self.build_attrs(final_attrs, self.attrs)
 
         if "class" not in final_attrs:
             final_attrs["class"] = ""


### PR DESCRIPTION
Currently, if you use custom attrs with the pagedown widget, they do not function. For example, if you set a form with 

`    stats = forms.CharField(label='Stats',
                            widget=PagedownWidget(),
                            max_length=150)`
The max_length attr will not prevent additional text from being added to the field, which results in a bad user experience. This should also allow you to pass in a attr dictionary to the widget constructor.