### PR TITLE
Update the example code to support Django 2.0

### DIFF
--- a/example/app/music/models.py
+++ b/example/app/music/models.py
@@ -11,7 +11,7 @@ class Album(models.Model):
     '''A music album.'''
     name = models.CharField(max_length=128)
     description = models.TextField(blank=True)
-    artist = models.ForeignKey(Artist)
+    artist = models.ForeignKey(Artist, on_delete=models.CASCADE)
 
 
 class Song(models.Model):
@@ -19,4 +19,4 @@ class Song(models.Model):
     name = models.CharField(max_length=128)
     description = models.TextField(blank=True)
     lyrics = models.TextField(blank=True)
-    album = models.ForeignKey(Album)
+    album = models.ForeignKey(Album, on_delete=models.CASCADE)

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.3
-Django==1.11
+Django==2.0
 django-pagedown==0.1.3
 packaging==16.8
 pyparsing==2.2.0


### PR DESCRIPTION
The example code will show the errors below on Django 2.0

> TypeError: __init__() missing 1 required positional argument: 'on_delete'

As Django 2.0 release notes say:

> The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations.