### PR TITLE
Fix `el.id` not being defined in DjangoPagedown.destroyEditor

### DIFF
--- a/pagedown/static/pagedown_init.js
+++ b/pagedown/static/pagedown_init.js
@@ -103,7 +103,7 @@ DjangoPagedown = (function() {
 
   var destroyEditor = function(element) {
     if (editors.hasOwnProperty(element.id)) {
-      delete editors[el.id];
+      delete editors[element.id];
       return true;
     }
     return false;


### PR DESCRIPTION
This seems like a regression from 9ffcbb7, as all instances of `el`
was replaced by `element`. However, this instance was missed.