### PR TITLE
Feature: Unique image upload directory

### DIFF
--- a/pagedown/views.py
+++ b/pagedown/views.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from django.conf import settings
@@ -11,6 +12,8 @@ from pagedown.forms import ImageUploadForm
 
 IMAGE_UPLOAD_PATH = getattr(
     settings, 'PAGEDOWN_IMAGE_UPLOAD_PATH', 'pagedown-uploads')
+IMAGE_UPLOAD_UNIQUE = getattr(
+    settings, 'PAGEDOWN_IMAGE_UPLOAD_UNIQUE', False)
 IMAGE_UPLOAD_ENABLED = getattr(
     settings, 'PAGEDOWN_IMAGE_UPLOAD_ENABLED', False)
 
@@ -27,7 +30,10 @@ def image_upload_view(request):
     form = ImageUploadForm(request.POST, request.FILES)
     if form.is_valid():
         image = request.FILES['image']
-        path = os.path.join(IMAGE_UPLOAD_PATH, image.name)
+        path_args = [IMAGE_UPLOAD_PATH, image.name]
+        if IMAGE_UPLOAD_UNIQUE:
+            path_args.insert(1, str(uuid.uuid4()))
+        path = os.path.join(*path_args)
         path = default_storage.save(path, image)
         url = default_storage.url(path)
         return JsonResponse({'success': True, 'url': url})


### PR DESCRIPTION
Implemented an optional setting, PAGEDOWN_IMAGE_UPLOAD_UNIQUE, that when enabled inserts a unique directory between the upload directory and the filename.

This is useful for situations where unique filenames are not guaranteed.

TODO: Update documentation