### PR TITLE
Bugfix: Handle undefined input in createEditor

### DIFF
--- a/pagedown/static/pagedown_init.js
+++ b/pagedown/static/pagedown_init.js
@@ -11,6 +11,9 @@ DjangoPagedown = (function() {
 
   var createEditor = function(element) {
     var input = element.getElementsByClassName("wmd-input")[0];
+    if (input === undefined) {
+      return
+    }
     var id = input.id.substr(9);
     if (!editors.hasOwnProperty(id)) {
       var editor = new Markdown.Editor(converter, id, {});


### PR DESCRIPTION
Short circuiting `createEditor` when input is undefined

This issue popped up when I was using a o2o model that was configured as inline, that itself has other inlines to m2m models, and when attempting to click the CTA to add a new m2m instance.

I believe this could be a symptom of the pagedown script finding references to elements that are not apart of the editor.
This patch is a bandaid and there may be a better solution for the situation/issue I have encountered.