### PR TITLE
Allow overriding upload path by widget argument

### DIFF
--- a/pagedown/static/pagedown_init.js
+++ b/pagedown/static/pagedown_init.js
@@ -57,6 +57,11 @@ DjangoPagedown = (function() {
                 var data = new FormData();
                 var xhr = new XMLHttpRequest();
                 data.append("image", file.files[0]);
+                // override upload dir?
+                var uploadDir = file.getAttribute("data-upload-dir-override");
+                if (uploadDir) {
+                  data.append("upload-dir-override", uploadDir);
+                }
                 xhr.open("POST", file.dataset.action, true);
                 xhr.addEventListener(
                   "load",

--- a/pagedown/templates/pagedown/forms/widgets/default.html
+++ b/pagedown/templates/pagedown/forms/widgets/default.html
@@ -16,7 +16,10 @@
             <div class="form-row">
                 <div>
                     <label class="label">From your computer</label>
-                    <input class="file-input" type="file" name="image" id="file" data-action="{% url 'pagedown-image-upload' %}" accept="image/*"/>
+                    <input class="file-input custom-file" type="file" name="image" id="file"
+                           data-action="{% url 'pagedown-image-upload' %}"
+                           {% if upload_dir %}data-upload-dir-override="{{ upload_dir }}"{% endif %}
+                           accept="image/*"/>
                 </div>
             </div>
             <div class="submit-row">

--- a/pagedown/views.py
+++ b/pagedown/views.py
@@ -18,6 +18,30 @@ IMAGE_UPLOAD_ENABLED = getattr(
     settings, 'PAGEDOWN_IMAGE_UPLOAD_ENABLED', False)
 
 
+def make_unique_path(dir_name, file_name):
+    """
+    Create a unique path for a file in a certain directory.
+
+    Appends '-%d' to the file name to make it unique - if necessary-
+    Args:
+        dir_name (str): the directory where the file will be placed (absolute)
+        file_name (str): the initial file name to use
+
+    Returns:
+        unique file name based on 'file_name'
+    """
+    unique_fn, ext = os.path.splitext(file_name)
+    dir_name = os.path.abspath(dir_name)
+    i = 0
+    while os.path.exists(os.path.join(dir_name, unique_fn + ext)):
+        i += 1
+        if i > 1000:
+            raise ValueError("Failed to find unique file name for %s in %s" % (file_name, dir_name))
+        unique_fn = "%s-%d" % (unique_fn, i)
+
+    return unique_fn + ext
+
+
 @login_required
 @csrf_exempt
 def image_upload_view(request):
@@ -30,9 +54,17 @@ def image_upload_view(request):
     form = ImageUploadForm(request.POST, request.FILES)
     if form.is_valid():
         image = request.FILES['image']
+        # check optional upload dir override
+        upload_dir_override = request.POST.get("upload-dir-override", "")
+        if upload_dir_override:
+            file_name = make_unique_path(os.path.join(settings.MEDIA_ROOT, upload_dir_override),
+                                         image.name)
+            path_args = [upload_dir_override, file_name]
+        else:
         path_args = [IMAGE_UPLOAD_PATH, image.name]
         if IMAGE_UPLOAD_UNIQUE:
             path_args.insert(1, str(uuid.uuid4()))
+
         path = os.path.join(*path_args)
         path = default_storage.save(path, image)
         url = default_storage.url(path)

--- a/pagedown/widgets.py
+++ b/pagedown/widgets.py
@@ -6,16 +6,18 @@ from django.contrib.admin import widgets
 class PagedownWidget(forms.Textarea):
     template_name = 'pagedown/forms/widgets/default.html'
 
-    def __init__(self, attrs=None):
+    def __init__(self, attrs=None, upload_dir=None):
         super(PagedownWidget, self).__init__(attrs=attrs)
         # Add wmd-input class for easier styling
         self.attrs['class'] = '{} wmd-input'.format(
             self.attrs.get('class', ''))
+        self.upload_dir = upload_dir
 
     def get_context(self, name, value, attrs):
         context = super(PagedownWidget, self).get_context(name, value, attrs)
         context["image_upload_enabled"] = getattr(
             settings, 'PAGEDOWN_IMAGE_UPLOAD_ENABLED', False)
+        context["upload_dir"] = self.upload_dir
         return context
 
     class Media:


### PR DESCRIPTION
I added an optional argument to PageDownWidget named `upload_dir`. If it is set, `IMAGE_UPLOAD_PATH` and `IMAGE_UPLOAD_UNIQUE` are ignored and the provided path is used instead. Like `IMAGE_UPLOAD_PATH`, `upload_dir` is inserted between MEDIA_ROOT and the image file name.

If `upload_dir` is used, the file input element gets a new attribute "data-upload-dir-override" which is added to the POST data by the JavaScript submit handler.

I also added a function that creates a unique file name for the uploaded image. This kind of overlapped with the IMAGE_UPLOAD_UNIQUE feature, but I like my solution better since UUID paths are very bulky. `make_unique_path` is only called if the `upload_dir` parameter is used.

If you like it, I can update your README, too.